### PR TITLE
TSDK-612 Use simplified ValueTypeIdentifier

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
 
   lazy val toplOrg = "co.topl"
 
-  lazy val bramblVersion = "2.0.0-alpha7"
+  lazy val bramblVersion = "2.0.0-alpha7+8-f8499bbf-SNAPSHOT"
   val bramblSdk = toplOrg %% "brambl-sdk" % bramblVersion
 
   val monocleCore = "dev.optics" %% "monocle-core" % "3.2.0"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
 
   lazy val toplOrg = "co.topl"
 
-  lazy val bramblVersion = "2.0.0-alpha7+8-f8499bbf-SNAPSHOT"
+  lazy val bramblVersion = "2.0.0-alpha7+1-460be034-SNAPSHOT"
   val bramblSdk = toplOrg %% "brambl-sdk" % bramblVersion
 
   val monocleCore = "dev.optics" %% "monocle-core" % "3.2.0"

--- a/src/main/scala/co/topl/brambl/cli/controllers/SimpleTransactionController.scala
+++ b/src/main/scala/co/topl/brambl/cli/controllers/SimpleTransactionController.scala
@@ -9,8 +9,7 @@ import co.topl.brambl.dataApi.WalletStateAlgebra
 import co.topl.brambl.models.GroupId
 import co.topl.brambl.models.LockAddress
 import co.topl.brambl.models.SeriesId
-import co.topl.brambl.models.box.QuantityDescriptorType
-import co.topl.brambl.syntax.GroupAndSeriesFungible
+import co.topl.brambl.syntax.AssetType
 import co.topl.brambl.syntax.GroupType
 import co.topl.brambl.syntax.LvlType
 import co.topl.brambl.syntax.SeriesType
@@ -53,12 +52,7 @@ class SimpleTransactionController[F[_]: Sync](
             case TokenType.lvl    => LvlType
             case TokenType.group  => GroupType(groupId.get)
             case TokenType.series => SeriesType(seriesId.get)
-            case TokenType.asset =>
-              GroupAndSeriesFungible(
-                groupId.get,
-                seriesId.get,
-                QuantityDescriptorType.LIQUID
-              )
+            case TokenType.asset => AssetType(groupId.get.value, seriesId.get.value)
             case _ => throw new Exception("Token type not supported")
           })
           res <- simplTransactionOps

--- a/src/main/scala/co/topl/brambl/cli/controllers/WalletController.scala
+++ b/src/main/scala/co/topl/brambl/cli/controllers/WalletController.scala
@@ -13,8 +13,7 @@ import co.topl.brambl.dataApi
 import co.topl.brambl.models.Indices
 import co.topl.brambl.models.LockAddress
 import co.topl.brambl.models.LockId
-import co.topl.brambl.models.box.QuantityDescriptorType
-import co.topl.brambl.syntax.GroupAndSeriesFungible
+import co.topl.brambl.syntax.AssetType
 import co.topl.brambl.syntax.GroupType
 import co.topl.brambl.syntax.LvlType
 import co.topl.brambl.syntax.SeriesType
@@ -377,10 +376,9 @@ class WalletController[F[_]: Sync](
         else if (x.transactionOutput.value.value.isSeries)
           SeriesType(x.transactionOutput.value.value.series.get.seriesId)
         else if (x.transactionOutput.value.value.isAsset)
-          GroupAndSeriesFungible(
-            x.transactionOutput.value.value.asset.get.groupId.get,
-            x.transactionOutput.value.value.asset.get.seriesId.get,
-            QuantityDescriptorType.LIQUID
+          AssetType(
+            x.transactionOutput.value.value.asset.get.groupId.get.value,
+            x.transactionOutput.value.value.asset.get.seriesId.get.value
           )
         else ()
       )
@@ -411,7 +409,7 @@ class WalletController[F[_]: Sync](
             "Group(" + Encoding.encodeToHex(groupId.toByteArray) + ")"
           case SeriesType(seriesId) =>
             "Series(" + Encoding.encodeToHex(seriesId.toByteArray) + ")"
-          case GroupAndSeriesFungible(groupId, seriesId, _) =>
+          case AssetType(groupId, seriesId) =>
             "Asset(" + Encoding.encodeToHex(
               groupId.toByteArray
             ) + ", " + Encoding


### PR DESCRIPTION
## Purpose

In https://github.com/Topl/BramblSc/pull/142 we simplified the ValueTypeIdentifier. In this PR, we updated it's usage to reflect. 

## Approach

- Updated BramblSc dependency
- Updated any usage of Asset Type's ValueTypeIdentifier.

## Testing

- ensure unit and integration tests pass (see GH actions)

## Tickets
* TSDK-612
