### PR TITLE
TSDK-716 Display GroupId Bug Fix (from demo)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - 2023-mm-dd (this date should be changed on release)
+
+### Changed
+
+- Various bug fixes and improvements
+
 ## [v2.0.0-beta1] - 2023-12-05
 
 ### Added

--- a/cli/src/main/scala/co/topl/brambl/cli/controllers/GenusQueryController.scala
+++ b/cli/src/main/scala/co/topl/brambl/cli/controllers/GenusQueryController.scala
@@ -50,7 +50,7 @@ class GenusQueryController[F[_]: Sync](
             .map { txos =>
               if (txos.isEmpty) Left("No UTXO found")
               else
-                Right(txos.map(_.display).mkString("\n"))
+                Right(txos.map(_.display).mkString("\n\n"))
             }
             .attempt
             .map {

--- a/cli/src/main/scala/co/topl/brambl/cli/controllers/GenusQueryController.scala
+++ b/cli/src/main/scala/co/topl/brambl/cli/controllers/GenusQueryController.scala
@@ -50,7 +50,7 @@ class GenusQueryController[F[_]: Sync](
             .map { txos =>
               if (txos.isEmpty) Left("No UTXO found")
               else
-                Right(txos.map(_.display).mkString)
+                Right(txos.map(_.display).mkString("\n"))
             }
             .attempt
             .map {

--- a/cli/src/main/scala/co/topl/brambl/cli/impl/WalletModeHelper.scala
+++ b/cli/src/main/scala/co/topl/brambl/cli/impl/WalletModeHelper.scala
@@ -3,19 +3,10 @@ package co.topl.brambl.cli.impl
 import cats.effect.kernel.Sync
 import co.topl.brambl.codecs.AddressCodecs
 import co.topl.brambl.dataApi
-import co.topl.brambl.syntax.AssetType
-import co.topl.brambl.syntax.GroupType
-import co.topl.brambl.syntax.LvlType
-import co.topl.brambl.syntax.SeriesType
+import co.topl.brambl.syntax.{AssetType, GroupType, LvlType, SeriesType}
 import co.topl.brambl.utils.Encoding
-import co.topl.genus.services.Txo
-import co.topl.genus.services.TxoState
-import co.topl.shared.models.LvlBalance
-import co.topl.shared.models.GroupTokenBalanceDTO
-import co.topl.shared.models.AssetTokenBalanceDTO
-import co.topl.shared.models.SeriesTokenBalanceDTO
-import co.topl.shared.models.UnknownBalanceDTO
-import co.topl.shared.models.BalanceDTO
+import co.topl.genus.services.{Txo, TxoState}
+import co.topl.shared.models._
 
 case class WalletModeHelper[F[_]: Sync](
     walletStateAlgebra: dataApi.WalletStateAlgebra[F],
@@ -113,12 +104,12 @@ case class WalletModeHelper[F[_]: Sync](
           case LvlType => LvlBalance(result.toString)
           case GroupType(groupId) =>
             GroupTokenBalanceDTO(
-              Encoding.encodeToHex(groupId.toByteArray),
+              Encoding.encodeToHex(groupId.value.toByteArray),
               result.toString
             )
           case SeriesType(seriesId) =>
             SeriesTokenBalanceDTO(
-              Encoding.encodeToHex(seriesId.toByteArray),
+              Encoding.encodeToHex(seriesId.value.toByteArray),
               result.toString
             )
           case AssetType(groupId, seriesId) =>

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
 
   lazy val toplOrg = "co.topl"
 
-  lazy val bramblVersion = "2.0.0-beta1+9-4f7cd1fd-SNAPSHOT"
+  lazy val bramblVersion = "2.0.0-beta1+5-03af7b4e-SNAPSHOT"
   val bramblSdk = toplOrg %% "brambl-sdk" % bramblVersion 
   val circeVersion = "0.15.0-M1"
 


### PR DESCRIPTION
## Purpose

### Set up steps:
1. Create wallet
  ```
  > brambl-cli wallet init --network private --password test --newwalletdb wallet.db --mnemonicfile wallet.txt --output wallet.json
  ```
2. Query genus for LVLs
  ```
  > brambl-cli genus-query utxo-by-address --from-fellowship noparty --from-template genesis -h localhost --port 9084 --walletdb wallet.db
  
  TxoAddress : 9xuuz3GWYWtFPxYWUg1v5KHpeCuhJfyZ2x2KzuxsVRLN#0
  ```
3. Create Group policy and save it to "policy.yml"
  ```
  label: MyGroupPolicy
  registrationUtxo: 9xuuz3GWYWtFPxYWUg1v5KHpeCuhJfyZ2x2KzuxsVRLN#0
  ```
4. Mint a Group Constructor Token
  ```
  > brambl-cli simple-minting create --from-fellowship noparty --from-template genesis  -h localhost --port 9084 -n private --keyfile wallet.json -w test -o my-tx.pbuf -i policy.yml  --mint-amount 1 --fee 1 --walletdb wallet.db --mint-token group
  > brambl-cli tx prove -w test --keyfile wallet.json -i my-tx.pbuf -o my-tx-proven.pbuf --walletdb wallet.db
  > brambl-cli tx broadcast -i my-tx-proven.pbuf -h localhost --port 9084
  ```

### Reproduce bug:
1. use `brambl-cli wallet balance` to get the balance
2. Using the GroupId from the printed balance, transfer the Group tokens to another wallet state

#### Before the fix

```
> brambl-cli wallet balance --from-fellowship noparty --from-template genesis --walletdb wallet.db --host localhost --port 9084

Group(0a205e08d4ca5b696461fdb25a20afe7404baa885211492200ab71670de60e830089): 1
LVL: 10000000

> brambl-cli simple-transaction create --from-fellowship noparty --from-template genesis --to-fellowship noparty --to-template genesis -w test --port 9084 -o transfer-tx.pbuf -n private -a 1 -h localhost -k wallet.json --walletdb wallet.db --fee 1 --transfer-token group --group-id 0a205e08d4ca5b696461fdb25a20afe7404baa885211492200ab71670de60e830089

Error: Option --group-id failed when given '0a205e08d4ca5b696461fdb25a20afe7404baa885211492200ab71670de60e830089'. Validation failed: GroupId.value: length must be 32 - Got [10, 32, 94, 8, -44, -54, 91, 105, 100, 97, -3, -78, 90, 32, -81, -25, 64, 75, -86, -120, 82, 17, 73, 34, 0, -85, 113, 103, 13, -26, 14, -125, 0, -119]
Error: Exactly group and groupId together, or series and seriesId, or only lvl must be specified
```

#### After the fix

```
> brambl-cli wallet balance --from-fellowship noparty --from-template genesis --walletdb wallet.db --host localhost --port 9084

Group(5e08d4ca5b696461fdb25a20afe7404baa885211492200ab71670de60e830089): 1
LVL: 10000000

> brambl-cli simple-transaction create --from-fellowship nofellowship --from-template genesis --to-fellowship nofellowship --to-template genesis --change-fellowship nofellowship --change-template genesis --change-interaction 2 -w test --port 9084 -o transfer-tx.pbuf -n private -a 1 -h localhost -k wallet.json --walletdb wallet.db --fee 1 --transfer-token group --group-id 5e08d4ca5b696461fdb25a20afe7404baa885211492200ab71670de60e830089

Transaction successfully created
```

## Approach

- Encode the value within the ByteString instead of the probuf model GroupId
- also minor fix to displaying TXOs (added newline characters)

## Testing

See `After the fix`

## Tickets
* TSDK-716