### PR TITLE
TSDK-761 Add digest support (part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated logback-classic to 1.4.14 to fix security vulnerability CVE-2023-6378.
 - Updated sqlite-jdbc to 3.45.0.0 to fix security vulnerability CVE-2023-32697.
+- The quivr expression supported to add a template now support the keywords: 
+`sha256` and `blake2b`. The `digest` keyword is not supported anymore.
+- The digests for `sha256` and `blake2b` use the hexadecimal representation of the
+digest instead of the base64 representation.
+- The `import-vks` command now supports empty files for the verification key when
+the fellowship is a `nofellowship`.
 
 ## [v2.0.0-beta3] - 2024-01-10
 

--- a/cli/src/it/scala/co/topl/brambl/cli/CommonTxOperations.scala
+++ b/cli/src/it/scala/co/topl/brambl/cli/CommonTxOperations.scala
@@ -643,6 +643,22 @@ trait CommonTxOperations
         )
       )
     )
+
+  def addTemplate(templateName: String, template: String) =
+    Kleisli[IO, WalletKeyConfig, ExitCode]((c: WalletKeyConfig) =>
+      Main.run(
+        List(
+          "templates",
+          "add",
+          "--walletdb",
+          c.walletFile,
+          "--template-name",
+          templateName,
+          "--lock-template",
+          template
+        )
+      )
+    )
   def recoverWallet(mnemonic: String) =
     Kleisli[IO, WalletKeyConfig, ExitCode]((c: WalletKeyConfig) =>
       Main.run(

--- a/cli/src/it/scala/co/topl/brambl/cli/WalletConstants.scala
+++ b/cli/src/it/scala/co/topl/brambl/cli/WalletConstants.scala
@@ -2,6 +2,8 @@ package co.topl.brambl.cli
 
 trait WalletConstants extends BaseConstants {
 
+  val EMPTY_FILE = s"$TMP_DIR/empty.txt"
+
   val WALLET = s"$TMP_DIR/wallet_wallet.db"
 
   val WALLET_MAIN_KEY = s"$TMP_DIR/wallet_mainkey.json"

--- a/cli/src/it/scala/co/topl/brambl/cli/WalletDigestPropositionTest.scala
+++ b/cli/src/it/scala/co/topl/brambl/cli/WalletDigestPropositionTest.scala
@@ -1,0 +1,70 @@
+package co.topl.brambl.cli
+
+import munit.CatsEffectSuite
+
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import cats.effect.ExitCode
+
+class WalletDigestPropositionTest
+    extends CatsEffectSuite
+    with WalletConstants
+    with CommonTxOperations {
+
+  val tmpDirectory = FunFixture[Path](
+    setup = { _ =>
+      val tmpDir = Paths.get(TMP_DIR).toFile()
+      if (tmpDir.exists()) {
+        Paths.get(TMP_DIR).toFile().listFiles().map(_.delete()).mkString("\n")
+        Files.deleteIfExists(Paths.get(TMP_DIR))
+      }
+      Files.createDirectory(Paths.get(TMP_DIR))
+      Files.createFile(Paths.get(EMPTY_FILE))
+    },
+    teardown = { _ => () }
+  )
+
+  tmpDirectory.test("Initialize wallet and add digest (sha256) template") { _ =>
+    for {
+      _ <- createWallet().run(walletContext)
+      _ <- assertIO(
+        addTemplate(
+          "sha256Template",
+          "threshold(1, sha256(b39f7e1305cd9107ed9af824fcb0729ce9888bbb7f219cc0b6731332105675dc))"
+        ).run(walletContext),
+        ExitCode.Success
+      )
+      _ <- importVk("nofellowship", "sha256Template", EMPTY_FILE).run(
+        walletContext
+      )
+      _ <- assertIO(
+        walletController(WALLET)
+          .currentaddress("nofellowship", "sha256Template", None),
+        Some("ptetP7jshHUxpB3Aep7erqzXRtSpcYnpxwcyCVQCpktktNhrUeSWgQH1hmvP")
+      )
+    } yield ()
+  }
+
+  tmpDirectory.test("Initialize wallet and add digest (blake2b) template") {
+    _ =>
+      for {
+        _ <- createWallet().run(walletContext)
+        _ <- assertIO(
+          addTemplate(
+            "blake2bTemplate",
+            "threshold(1, blake2b(b39f7e1305cd9107ed9af824fcb0729ce9888bbb7f219cc0b6731332105675dc))"
+          ).run(walletContext),
+          ExitCode.Success
+        )
+        _ <- importVk("nofellowship", "blake2bTemplate", EMPTY_FILE).run(
+          walletContext
+        )
+        _ <- assertIO(
+          walletController(WALLET)
+            .currentaddress("nofellowship", "blake2bTemplate", None),
+          Some("ptetP7jshHUzFqDR9cjYFnRt5caJAYmUVToDkmjSzvXUjVMFZDtDoEc7tRfT")
+        )
+      } yield ()
+  }
+}

--- a/cli/src/main/scala/co/topl/brambl/cli/controllers/WalletController.scala
+++ b/cli/src/main/scala/co/topl/brambl/cli/controllers/WalletController.scala
@@ -60,7 +60,7 @@ class WalletController[F[_]: Sync](
         })
         .sequence
         .flatMap(
-          _.map(
+          _.map(_.trim()).filterNot(_.isEmpty()).map(
             // TODO: replace with proper serialization in TSDK-476
             vk =>
               // we derive the key once

--- a/cli/src/main/scala/co/topl/brambl/cli/impl/QuivrFastParser.scala
+++ b/cli/src/main/scala/co/topl/brambl/cli/impl/QuivrFastParser.scala
@@ -269,7 +269,7 @@ object TemplateAST {
               if (decoded.length != 32)
                 InvalidQuivrTemplate(
                   location,
-                  "Blake2b256 digest must be 32 bytes"
+                  "Sha256 digest must be 32 bytes"
                 ).invalidNel
               else
                 PropositionTemplate

--- a/cli/src/main/scala/co/topl/brambl/cli/impl/QuivrFastParser.scala
+++ b/cli/src/main/scala/co/topl/brambl/cli/impl/QuivrFastParser.scala
@@ -47,7 +47,9 @@ case class Locked(location: Int, someData: Option[String]) extends TemplateAST
 
 case class Tick(location: Int, minTick: Long, maxTick: Long) extends TemplateAST
 
-case class Digest(location: Int, digest: String) extends TemplateAST
+case class Sha256Digest(location: Int, digest: String) extends TemplateAST
+
+case class Blake2bDigest(location: Int, digest: String) extends TemplateAST
 
 object TemplateAST {
 
@@ -232,21 +234,50 @@ object TemplateAST {
               .TickTemplate[F](min, max)
               .validNel
         )
-      case Digest(location, digest) =>
+      case Blake2bDigest(location, digest) =>
         State.pure(
-          Encoding.decodeFromBase58(digest) match {
+          Encoding.decodeFromHex(digest) match {
             case Left(_) =>
               InvalidQuivrTemplate(
                 location,
-                "Invalid base58 encoding"
+                "Invalid hexadecimal encoding"
               ).invalidNel
             case Right(decoded) =>
-              PropositionTemplate
-                .DigestTemplate[F](
-                  "Blake2b256",
-                  new models.Digest(ByteString.copyFrom(decoded))
-                )
-                .validNel
+              if (decoded.length != 32)
+                InvalidQuivrTemplate(
+                  location,
+                  "Blake2b256 digest must be 32 bytes"
+                ).invalidNel
+              else
+                PropositionTemplate
+                  .DigestTemplate[F](
+                    "Blake2b256",
+                    new models.Digest(ByteString.copyFrom(decoded))
+                  )
+                  .validNel
+          }
+        )
+      case Sha256Digest(location, digest) =>
+        State.pure(
+          Encoding.decodeFromHex(digest) match {
+            case Left(_) =>
+              InvalidQuivrTemplate(
+                location,
+                "Invalid hexadecimal encoding"
+              ).invalidNel
+            case Right(decoded) =>
+              if (decoded.length != 32)
+                InvalidQuivrTemplate(
+                  location,
+                  "Blake2b256 digest must be 32 bytes"
+                ).invalidNel
+              else
+                PropositionTemplate
+                  .DigestTemplate[F](
+                    "Sha256",
+                    new models.Digest(ByteString.copyFrom(decoded))
+                  )
+                  .validNel
           }
         )
     }
@@ -295,26 +326,44 @@ trait QuivrFastParser[F[_]] {
     }
 
   def digest[$: P]: P[TemplateAST] =
-    P(Index ~ P("digest") ~ P("(") ~ base58Chars ~ P(")")).map {
-      case (location, base58) =>
-        Digest(location, base58)
+    sha256 | blake2b
+
+  def sha256[$: P]: P[TemplateAST] =
+    P(Index ~ P("sha256") ~ P("(") ~ hexChars ~ P(")")).map {
+      case (location, hex) =>
+        Sha256Digest(location, hex)
+    }
+  def blake2b[$: P]: P[TemplateAST] =
+    P(Index ~ P("blake2b") ~ P("(") ~ hexChars ~ P(")")).map {
+      case (location, hex) =>
+        Blake2bDigest(location, hex)
     }
 
   def locked[$: P]: P[TemplateAST] =
     P(Index ~ P("locked") ~ P("(") ~ base58CharsOrEmpty ~ P(")")).map {
-      case (location, base58) =>
-        Locked(location, if (base58.trim().isEmpty()) None else Some(base58))
+      case (location, hex) =>
+        Locked(location, if (hex.trim().isEmpty()) None else Some(hex))
     }
 
-  def base58Char[$:P] = P(CharIn(
-    "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
-  ))
+  def hexChar[$: P] = P(
+    CharIn(
+      "0123456789ABCDEFabcdef"
+    )
+  )
 
+  def base58Char[$: P] = P(
+    CharIn(
+      "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz"
+    )
+  )
   def base58CharsOrEmpty[$: P]: P[String] =
     base58Char.rep.!
 
-  def base58Chars[$: P]: P[String] =
-    base58Char.rep(1).!
+  def hexCharsOrEmpty[$: P]: P[String] =
+    hexChar.rep.!
+
+  def hexChars[$: P]: P[String] =
+    hexChar.rep(1).!
 
   def signature[$: P]: P[TemplateAST] =
     P(Index ~ P("sign") ~ P("(") ~ decimal ~ P(")")).map {

--- a/cli/src/main/scala/co/topl/brambl/cli/views/WalletModelDisplayOps.scala
+++ b/cli/src/main/scala/co/topl/brambl/cli/views/WalletModelDisplayOps.scala
@@ -73,8 +73,10 @@ object WalletModelDisplayOps {
         s"height($min, $max)"
       case PropositionTemplate.TickTemplate(min, max) =>
         s"tick($min, $max)"
-      case PropositionTemplate.DigestTemplate(_, digest) =>
-        s"digest(${Encoding.encodeToBase58(digest.value.toByteArray())})"
+      case PropositionTemplate.DigestTemplate("Sha256", digest) =>
+        s"sha256(${Encoding.encodeToHex(digest.value.toByteArray())})"
+      case PropositionTemplate.DigestTemplate("Blake2b256", digest) =>
+        s"blake2b(${Encoding.encodeToHex(digest.value.toByteArray())})"
     }
   }
 

--- a/cli/src/test/scala/co/topl/brambl/cli/ParamsWalletModuleTest.scala
+++ b/cli/src/test/scala/co/topl/brambl/cli/ParamsWalletModuleTest.scala
@@ -1,25 +1,45 @@
 package co.topl.brambl.cli
 
-
 import munit.FunSuite
 import scopt.OParser
+
+import java.nio.file.Files
+import java.nio.file.Paths
+import java.nio.file.Path
 
 class ParamsWalletModuleTest extends FunSuite {
 
   import BramblCliParamsParserModule._
 
-  test("Test valid wallet create") {
+  val tmpWallet = FunFixture[(String, String)](
+    setup = { _ =>
+      val initialWalletDb = Paths.get("wallet.db")
+      val initialMnemonic = Paths.get("mnemonic.txt")
+      if (Files.exists(initialWalletDb))
+        Files.delete(initialWalletDb)
+      if (Files.exists(initialMnemonic))
+        Files.delete(initialMnemonic)
+      (
+        initialWalletDb.toAbsolutePath().toString(),
+        initialMnemonic.toAbsolutePath().toString()
+      )
+    },
+    teardown = { _ => () }
+  )
+
+  tmpWallet.test("Test valid wallet create") { walletAndMnemonic =>
+    val (wallet, mnemonic) = walletAndMnemonic
     val args0 = List(
       "wallet",
       "init",
       "-w",
       "test",
       "--newwalletdb",
-      "wallet.db",
+      wallet,
       "-n",
       "private",
       "--mnemonicfile",
-      "mnemonic.txt"
+      mnemonic
     )
     assert(OParser.parse(paramParser, args0, BramblCliParams()).isDefined)
     val args1 = List(
@@ -62,7 +82,7 @@ class ParamsWalletModuleTest extends FunSuite {
         .isEmpty
     )
   }
-  test("Test valid key recovery") {
+  tmpWallet.test("Test valid key recovery") { _ =>
     val args0 = List(
       "wallet",
       "recover-keys",

--- a/cli/src/test/scala/co/topl/brambl/cli/impl/QuivrFastParserSpec.scala
+++ b/cli/src/test/scala/co/topl/brambl/cli/impl/QuivrFastParserSpec.scala
@@ -64,8 +64,16 @@ class QuivrFastParserSpec extends munit.FunSuite {
       )
     assertEquals(actual, input)
   }
-  test("Parser should parse locked digest") {
-    val input = "threshold(1, digest(6TcbSYWweHnZgEY2oVopiUue6xbZAE1NTkq77u8uFvD8))"
+  test("Parser should parse locked blake2b digest") {
+    val input = "threshold(1, blake2b(a28f43e7ba06f79b31b189cfee16e160fba1c0ea8f2c4cc8ca38fa567fbca2e3))"
+    val actual =
+      WalletModelDisplayOps.serialize(
+        QuivrFastParser.make[Id].parseQuivr(input).toOption.get
+      )
+    assertEquals(actual, input)
+  }
+  test("Parser should parse locked sha256 digest") {
+    val input = "threshold(1, sha256(b39f7e1305cd9107ed9af824fcb0729ce9888bbb7f219cc0b6731332105675dc))"
     val actual =
       WalletModelDisplayOps.serialize(
         QuivrFastParser.make[Id].parseQuivr(input).toOption.get

--- a/microsite/docs/cli-reference/wallet-mode.md
+++ b/microsite/docs/cli-reference/wallet-mode.md
@@ -63,7 +63,7 @@ Recover Wallet Main Key
   -o, --output <value>     The output file. (mandatory)
   --newwalletdb <value>    Wallet DB file. (mandatory)
   -P, --passphrase <value>
-                           Passphrase for the encrypted key. (optional))
+                           Passphrase for the encrypted key. (optional)
 Command: wallet current-address [options]
 Obtain current address
   --walletdb <value>       Wallet DB file. (mandatory)


### PR DESCRIPTION
We modified the template controllers so that it supports both sha256 and blake2b.

## Purpose

The goal of this PR is to add digest support for both blake2b and sha256 to the `brambl-cli`. The previous version only supported blake2b.

## Approach

We modified the grammar and serializer of quivr expressions for the template modes of the cli. There are two main changes:

- Before, we used Base58 for the digest, as it is what was used by the JSON serialization of BramblSc. The serialization engine stays the same.
- The quivr expression supported to add a template now support the keywords: `sha256` and `blake2b`. The `digest` keyword is not supported anymore.

## Testing

We added unit tests and integration tests for these new features.

## Tickets

* TSDK-761