### PR TITLE
TSDK-761 Digest support part 2

### DIFF
--- a/.github/workflows/sbt_checkPR.yml
+++ b/.github/workflows/sbt_checkPR.yml
@@ -31,7 +31,7 @@ jobs:
       # Label used to access the service container
       bifrost:
         # Docker Hub image
-        image: ghcr.io/topl/bifrost-node:2.0.0-beta2-13-84e61aab
+        image: ghcr.io/topl/bifrost-node:2.0.0-beta2-8-3e6057e0
         #
         ports:
           - 9084:9084 

--- a/.github/workflows/sbt_checkPR.yml
+++ b/.github/workflows/sbt_checkPR.yml
@@ -31,7 +31,7 @@ jobs:
       # Label used to access the service container
       bifrost:
         # Docker Hub image
-        image: docker.io/toplprotocol/bifrost-node:2.0.0-beta2
+        image: ghcr.io/topl/bifrost-node:2.0.0-beta2-8-3e6057e0
         #
         ports:
           - 9084:9084 

--- a/.github/workflows/sbt_checkPR.yml
+++ b/.github/workflows/sbt_checkPR.yml
@@ -31,7 +31,7 @@ jobs:
       # Label used to access the service container
       bifrost:
         # Docker Hub image
-        image: docker.io/toplprotocol/bifrost-node:2.0.0-alpha10
+        image: docker.io/toplprotocol/bifrost-node:2.0.0-beta2
         #
         ports:
           - 9084:9084 

--- a/.github/workflows/sbt_checkPR.yml
+++ b/.github/workflows/sbt_checkPR.yml
@@ -31,7 +31,7 @@ jobs:
       # Label used to access the service container
       bifrost:
         # Docker Hub image
-        image: ghcr.io/topl/bifrost-node:2.0.0-beta2-8-3e6057e0
+        image: ghcr.io/topl/bifrost-node:2.0.0-beta2-13-84e61aab
         #
         ports:
           - 9084:9084 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - 2023-mm-dd (this date should be changed on release)
 
+### Added
+
+- Added 2 operations `add-secret` and `get-preimage` to the `wallet` mode.
+
 ### Changed
 
 - Updated logback-classic to 1.4.14 to fix security vulnerability CVE-2023-6378.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 digest instead of the base64 representation.
 - The `import-vks` command now supports empty files for the verification key when
 the fellowship is a `nofellowship`.
+- Migrated the `BravlSc` dependency to `2.0.0-beta3`.
+- Migrated the `Bifrost` dependency to `2.0.0-beta2`.
 
 ## [v2.0.0-beta3] - 2024-01-10
 

--- a/cli/src/it/scala/co/topl/brambl/cli/AliceConstants.scala
+++ b/cli/src/it/scala/co/topl/brambl/cli/AliceConstants.scala
@@ -70,6 +70,8 @@ trait AliceConstants extends BaseConstants {
 
   val ALICE_OR_VK = s"$TMP_DIR/alice_or_vk.json"
 
+  val BOB_OR_VK = s"$TMP_DIR/bob_or_vk.json"
+
   val ALICE_VK_AND = s"$TMP_DIR/alice_vk_and.json"
 
   val ALICE_SECOND_TX_RAW = s"$TMP_DIR/alice_second_tx.pbuf"

--- a/cli/src/it/scala/co/topl/brambl/cli/BobConstants.scala
+++ b/cli/src/it/scala/co/topl/brambl/cli/BobConstants.scala
@@ -22,6 +22,8 @@ trait BobConstants extends BaseConstants {
 
   val BOB_VK = s"$TMP_DIR/bob_vk.json"
 
+  val EMPTY_VK = s"$TMP_DIR/empty.txt"
+
   val BOB_AND_VK = s"$TMP_DIR/bob_and_vk.json"
 
   val BOB_COMPLEX_VK_OR = s"$TMP_DIR/bob_complex_vk_or.json"

--- a/cli/src/it/scala/co/topl/brambl/cli/CommonFunctions.scala
+++ b/cli/src/it/scala/co/topl/brambl/cli/CommonFunctions.scala
@@ -82,7 +82,7 @@ trait CommonFunctions extends PolicyTemplates {
           _ <- IO.sleep(5.seconds)
         } yield queryRes)
           .iterateUntil(_ == ExitCode.Success),
-        60.seconds
+        120.seconds
       )
     } yield res
   }

--- a/cli/src/it/scala/co/topl/brambl/cli/CommonFunctions.scala
+++ b/cli/src/it/scala/co/topl/brambl/cli/CommonFunctions.scala
@@ -40,7 +40,7 @@ trait CommonFunctions extends PolicyTemplates {
           _ <- IO.sleep(5.seconds)
         } yield queryRes)
           .iterateUntil(_ == ExitCode.Success),
-        180.seconds
+        240.seconds
       )
       ALICE_TO_ADDRESS <- walletController(ALICE_WALLET).currentaddress("self", "default", None)
       _ <- IO.println(s"Alice's address is $ALICE_TO_ADDRESS")
@@ -82,7 +82,7 @@ trait CommonFunctions extends PolicyTemplates {
           _ <- IO.sleep(5.seconds)
         } yield queryRes)
           .iterateUntil(_ == ExitCode.Success),
-        180.seconds
+        240.seconds
       )
     } yield res
   }

--- a/cli/src/it/scala/co/topl/brambl/cli/CommonFunctions.scala
+++ b/cli/src/it/scala/co/topl/brambl/cli/CommonFunctions.scala
@@ -40,7 +40,7 @@ trait CommonFunctions extends PolicyTemplates {
           _ <- IO.sleep(5.seconds)
         } yield queryRes)
           .iterateUntil(_ == ExitCode.Success),
-        120.seconds
+        180.seconds
       )
       ALICE_TO_ADDRESS <- walletController(ALICE_WALLET).currentaddress("self", "default", None)
       _ <- IO.println(s"Alice's address is $ALICE_TO_ADDRESS")
@@ -82,7 +82,7 @@ trait CommonFunctions extends PolicyTemplates {
           _ <- IO.sleep(5.seconds)
         } yield queryRes)
           .iterateUntil(_ == ExitCode.Success),
-        120.seconds
+        180.seconds
       )
     } yield res
   }

--- a/cli/src/it/scala/co/topl/brambl/cli/CommonFunctions.scala
+++ b/cli/src/it/scala/co/topl/brambl/cli/CommonFunctions.scala
@@ -40,7 +40,7 @@ trait CommonFunctions extends PolicyTemplates {
           _ <- IO.sleep(5.seconds)
         } yield queryRes)
           .iterateUntil(_ == ExitCode.Success),
-        60.seconds
+        120.seconds
       )
       ALICE_TO_ADDRESS <- walletController(ALICE_WALLET).currentaddress("self", "default", None)
       _ <- IO.println(s"Alice's address is $ALICE_TO_ADDRESS")

--- a/cli/src/it/scala/co/topl/brambl/cli/CommonTxOperations.scala
+++ b/cli/src/it/scala/co/topl/brambl/cli/CommonTxOperations.scala
@@ -659,6 +659,36 @@ trait CommonTxOperations
         )
       )
     )
+  def addSecret(secret: String, digestAlgorithm: String) =
+    Kleisli[IO, WalletKeyConfig, ExitCode]((c: WalletKeyConfig) =>
+      Main.run(
+        List(
+          "wallet",
+          "add-secret",
+          "--walletdb",
+          c.walletFile,
+          "--secret",
+          secret,
+          "--digest",
+          digestAlgorithm
+        )
+      )
+    )
+  def getPreimage(digestText: String, digestAlgorithm: String) =
+    Kleisli[IO, WalletKeyConfig, ExitCode]((c: WalletKeyConfig) =>
+      Main.run(
+        List(
+          "wallet",
+          "get-preimage",
+          "--walletdb",
+          c.walletFile,
+          "--digest-text",
+          digestText,
+          "--digest",
+          digestAlgorithm
+        )
+      )
+    )
   def recoverWallet(mnemonic: String) =
     Kleisli[IO, WalletKeyConfig, ExitCode]((c: WalletKeyConfig) =>
       Main.run(

--- a/cli/src/it/scala/co/topl/brambl/cli/ComplexTransactionProveTest.scala
+++ b/cli/src/it/scala/co/topl/brambl/cli/ComplexTransactionProveTest.scala
@@ -115,7 +115,7 @@ class ComplexTransactionProveTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          60.seconds
+          120.seconds
         )
       } yield res,
       ExitCode.Success
@@ -207,7 +207,7 @@ class ComplexTransactionProveTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          60.seconds
+          120.seconds
         )
       } yield res,
       ExitCode.Success
@@ -266,7 +266,7 @@ class ComplexTransactionProveTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          60.seconds
+          120.seconds
         )
         _ <- IO.println("Sync alice's account")
         _ <- syncWallet("alice_bob_0", "or_sign").run(aliceContext)
@@ -277,7 +277,7 @@ class ComplexTransactionProveTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          60.seconds
+          120.seconds
         )
       } yield res,
       ExitCode.Success
@@ -347,7 +347,7 @@ class ComplexTransactionProveTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          60.seconds
+          120.seconds
         )
         _ <- IO.println("Sync alice's and account")
         _ <- syncWallet("alice_bob_0", "and_sign").run(aliceContext)
@@ -360,7 +360,7 @@ class ComplexTransactionProveTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          60.seconds
+          120.seconds
         )
       } yield res,
       ExitCode.Success

--- a/cli/src/it/scala/co/topl/brambl/cli/ComplexTransactionProveTest.scala
+++ b/cli/src/it/scala/co/topl/brambl/cli/ComplexTransactionProveTest.scala
@@ -115,7 +115,7 @@ class ComplexTransactionProveTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          120.seconds
+          180.seconds
         )
       } yield res,
       ExitCode.Success
@@ -207,7 +207,7 @@ class ComplexTransactionProveTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          120.seconds
+          180.seconds
         )
       } yield res,
       ExitCode.Success
@@ -266,7 +266,7 @@ class ComplexTransactionProveTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          120.seconds
+          180.seconds
         )
         _ <- IO.println("Sync alice's account")
         _ <- syncWallet("alice_bob_0", "or_sign").run(aliceContext)
@@ -347,7 +347,7 @@ class ComplexTransactionProveTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          120.seconds
+          180.seconds
         )
         _ <- IO.println("Sync alice's and account")
         _ <- syncWallet("alice_bob_0", "and_sign").run(aliceContext)
@@ -360,7 +360,7 @@ class ComplexTransactionProveTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          120.seconds
+          180.seconds
         )
       } yield res,
       ExitCode.Success

--- a/cli/src/it/scala/co/topl/brambl/cli/ComplexTransactionProveTest.scala
+++ b/cli/src/it/scala/co/topl/brambl/cli/ComplexTransactionProveTest.scala
@@ -115,7 +115,7 @@ class ComplexTransactionProveTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          180.seconds
+          240.seconds
         )
       } yield res,
       ExitCode.Success
@@ -207,7 +207,7 @@ class ComplexTransactionProveTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          180.seconds
+          240.seconds
         )
       } yield res,
       ExitCode.Success
@@ -266,7 +266,7 @@ class ComplexTransactionProveTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          180.seconds
+          240.seconds
         )
         _ <- IO.println("Sync alice's account")
         _ <- syncWallet("alice_bob_0", "or_sign").run(aliceContext)
@@ -277,7 +277,7 @@ class ComplexTransactionProveTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          120.seconds
+          240.seconds
         )
       } yield res,
       ExitCode.Success
@@ -347,7 +347,7 @@ class ComplexTransactionProveTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          180.seconds
+          240.seconds
         )
         _ <- IO.println("Sync alice's and account")
         _ <- syncWallet("alice_bob_0", "and_sign").run(aliceContext)
@@ -360,7 +360,7 @@ class ComplexTransactionProveTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          180.seconds
+          240.seconds
         )
       } yield res,
       ExitCode.Success

--- a/cli/src/it/scala/co/topl/brambl/cli/ComplexTransactionTemplates.scala
+++ b/cli/src/it/scala/co/topl/brambl/cli/ComplexTransactionTemplates.scala
@@ -120,6 +120,7 @@ trait ComplexTransactionTemplates {
       aliceAndKey: String,
       bobAndKey: String,
       aliceOrKey: String,
+      bobOrKey: String,
       andAmount: Long,
       orAmount: Long,
       addressBob: String
@@ -133,6 +134,7 @@ trait ComplexTransactionTemplates {
             aliceAndKey,
             bobAndKey,
             aliceOrKey,
+            bobOrKey,
             andAmount,
             orAmount,
             addressBob
@@ -148,6 +150,7 @@ trait ComplexTransactionTemplates {
       aliceAndKey: String,
       bobAndKey: String,
       aliceOrKey: String,
+      bobOrKey: String,
       andAmount: Long,
       orAmount: Long,
       addressBob: String
@@ -161,6 +164,8 @@ trait ComplexTransactionTemplates {
         |    vk: $bobAndKey
         |  - id: aliceOr
         |    vk: $aliceOrKey
+        |  - id: bobOr
+        |    vk: $bobOrKey
         |
         |inputs:
         |  - address: $andUtxoAddress
@@ -176,7 +181,7 @@ trait ComplexTransactionTemplates {
         |     - index: 0
         |       identifier: aliceOr
         |     - index: 1
-        |       identifier: aliceOr
+        |       identifier: bobOr
         |    proposition: threshold(1, sign(0) or sign(1))
         |    value: $orAmount
         |outputs:

--- a/cli/src/it/scala/co/topl/brambl/cli/ComplexTransactionWithFileTest.scala
+++ b/cli/src/it/scala/co/topl/brambl/cli/ComplexTransactionWithFileTest.scala
@@ -420,7 +420,7 @@ class ComplexTransactionWithFileTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          120.seconds
+          180.seconds
         )
       } yield res,
       ExitCode.Success

--- a/cli/src/it/scala/co/topl/brambl/cli/ComplexTransactionWithFileTest.scala
+++ b/cli/src/it/scala/co/topl/brambl/cli/ComplexTransactionWithFileTest.scala
@@ -48,7 +48,7 @@ class ComplexTransactionWithFileTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          60.seconds
+          120.seconds
         )
         ALICE_TO_ADDRESS <- walletController(ALICE_WALLET).currentaddress("self", "default", None)
         genesisAddress <- walletController(ALICE_WALLET)
@@ -111,7 +111,7 @@ class ComplexTransactionWithFileTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          60.seconds
+          120.seconds
         )
       } yield res,
       ExitCode.Success
@@ -290,7 +290,7 @@ class ComplexTransactionWithFileTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          60.seconds
+          120.seconds
         )
         res <- IO.asyncForIO.timeout(
           (for {
@@ -301,7 +301,7 @@ class ComplexTransactionWithFileTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          60.seconds
+          120.seconds
         )
       } yield res,
       ExitCode.Success
@@ -420,7 +420,7 @@ class ComplexTransactionWithFileTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          60.seconds
+          120.seconds
         )
       } yield res,
       ExitCode.Success

--- a/cli/src/it/scala/co/topl/brambl/cli/ComplexTransactionWithFileTest.scala
+++ b/cli/src/it/scala/co/topl/brambl/cli/ComplexTransactionWithFileTest.scala
@@ -48,7 +48,7 @@ class ComplexTransactionWithFileTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          120.seconds
+          180.seconds
         )
         ALICE_TO_ADDRESS <- walletController(ALICE_WALLET).currentaddress("self", "default", None)
         genesisAddress <- walletController(ALICE_WALLET)
@@ -111,7 +111,7 @@ class ComplexTransactionWithFileTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          120.seconds
+          180.seconds
         )
       } yield res,
       ExitCode.Success
@@ -290,7 +290,7 @@ class ComplexTransactionWithFileTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          120.seconds
+          180.seconds
         )
         res <- IO.asyncForIO.timeout(
           (for {
@@ -301,7 +301,7 @@ class ComplexTransactionWithFileTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          120.seconds
+          180.seconds
         )
       } yield res,
       ExitCode.Success

--- a/cli/src/it/scala/co/topl/brambl/cli/ComplexTransactionWithFileTest.scala
+++ b/cli/src/it/scala/co/topl/brambl/cli/ComplexTransactionWithFileTest.scala
@@ -48,7 +48,7 @@ class ComplexTransactionWithFileTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          180.seconds
+          240.seconds
         )
         ALICE_TO_ADDRESS <- walletController(ALICE_WALLET).currentaddress("self", "default", None)
         genesisAddress <- walletController(ALICE_WALLET)
@@ -111,7 +111,7 @@ class ComplexTransactionWithFileTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          180.seconds
+          240.seconds
         )
       } yield res,
       ExitCode.Success
@@ -176,14 +176,14 @@ class ComplexTransactionWithFileTest
           exportVk("alice_bob_0", "or_sign", BOB_COMPLEX_VK_OR).run(bobContext),
           ExitCode.Success
         )
-        _ <- IO.println("Importing or VK to alice's wallet")
+        _ <- IO.println("Importing or VK to bob's wallet")
         _ <- assertIO(
           importVk("alice_bob_0", "or_sign", ALICE_COMPLEX_VK_OR).run(
             bobContext
           ),
           ExitCode.Success
         )
-        _ <- IO.println("Importing or VK to bob's wallet")
+        _ <- IO.println("Importing or VK to alice's wallet")
         _ <- assertIO(
           importVk("alice_bob_0", "or_sign", BOB_COMPLEX_VK_OR).run(
             aliceContext
@@ -204,14 +204,14 @@ class ComplexTransactionWithFileTest
           ),
           ExitCode.Success
         )
-        _ <- IO.println("Importing and VK to alice's wallet")
+        _ <- IO.println("Importing and VK to bob's wallet")
         _ <- assertIO(
           importVk("alice_bob_0", "and_sign", ALICE_COMPLEX_VK_AND).run(
             bobContext
           ),
           ExitCode.Success
         )
-        _ <- IO.println("Importing VK to bob's wallet")
+        _ <- IO.println("Importing VK to alice's wallet")
         _ <- assertIO(
           importVk("alice_bob_0", "and_sign", BOB_COMPLEX_VK_AND).run(
             aliceContext
@@ -290,7 +290,7 @@ class ComplexTransactionWithFileTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          180.seconds
+          240.seconds
         )
         res <- IO.asyncForIO.timeout(
           (for {
@@ -301,7 +301,7 @@ class ComplexTransactionWithFileTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          180.seconds
+          240.seconds
         )
       } yield res,
       ExitCode.Success
@@ -352,6 +352,12 @@ class ComplexTransactionWithFileTest
           ),
           ExitCode.Success
         )
+        _ <- assertIO(
+          exportFinalVk("alice_bob_0", "or_sign", 1, BOB_OR_VK).run(
+            bobContext
+          ),
+          ExitCode.Success
+        )
         aliceAndKey <- Resource
           .make(IO(Source.fromFile(ALICE_AND_VK)))(f => IO(f.close()))
           .use { file =>
@@ -373,6 +379,13 @@ class ComplexTransactionWithFileTest
               file.getLines().mkString
             )
           }
+        bobOrKey <- Resource
+          .make(IO(Source.fromFile(BOB_OR_VK)))(f => IO(f.close()))
+          .use { file =>
+            IO(
+              file.getLines().mkString
+            )
+          }
         _ <- createSharedTemplatesToBob(
           ALICE_THIRD_COMPLEX_TX,
           andUtxo,
@@ -380,6 +393,7 @@ class ComplexTransactionWithFileTest
           aliceAndKey,
           bobAndKey,
           aliceOrKey,
+          bobOrKey,
           1000,
           1000,
           bobAddress.get
@@ -420,7 +434,7 @@ class ComplexTransactionWithFileTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          180.seconds
+          240.seconds
         )
       } yield res,
       ExitCode.Success

--- a/cli/src/it/scala/co/topl/brambl/cli/DigestTransactionTest.scala
+++ b/cli/src/it/scala/co/topl/brambl/cli/DigestTransactionTest.scala
@@ -94,7 +94,7 @@ class DigestTransactionTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          120.seconds
+          240.seconds
         )
       } yield res,
       ExitCode.Success
@@ -148,7 +148,7 @@ class DigestTransactionTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          120.seconds
+          240.seconds
         )
       } yield res,
       ExitCode.Success

--- a/cli/src/it/scala/co/topl/brambl/cli/DigestTransactionTest.scala
+++ b/cli/src/it/scala/co/topl/brambl/cli/DigestTransactionTest.scala
@@ -1,0 +1,158 @@
+package co.topl.brambl.cli
+
+import cats.effect.ExitCode
+import cats.effect.IO
+import munit.CatsEffectSuite
+
+import scala.concurrent.duration.Duration
+import java.nio.file.Files
+import java.nio.file.Paths
+
+class DigestTransactionTest
+    extends CatsEffectSuite
+    with CommonFunctions
+    with AliceConstants
+    with CommonTxOperations
+    with BobConstants {
+  override val munitTimeout = Duration(180, "s")
+
+  tmpDirectory.test("Move funds from genesis to alice") { _ =>
+    assertIO(
+      moveFundsFromGenesisToAlice(),
+      ExitCode.Success
+    )
+  }
+
+  test("Move funds from alice to digest locked account") {
+    import scala.concurrent.duration._
+    assertIO(
+      for {
+        _ <- IO.println("Create a wallet for bob")
+        _ <- assertIO(createWallet().run(bobContext), ExitCode.Success)
+        _ <- IO.println("Add bob's digest fellowship to bob's wallet")
+        _ <- assertIO(
+          addFellowshipToWallet("bob_digest_fellowship").run(bobContext),
+          ExitCode.Success
+        )
+        _ <- IO.println("Add a template to bob's wallet")
+        _ <- assertIO(
+          addTemplateToWallet(
+            "digest_template",
+            "threshold(1, sign(0) and sha256(b39f7e1305cd9107ed9af824fcb0729ce9888bbb7f219cc0b6731332105675dc))"
+          ).run(bobContext),
+          ExitCode.Success
+        )
+        _ <- IO.println("Importing VK to bob's wallet")
+        _ <- IO(Files.createFile(Paths.get(EMPTY_VK)))
+        _ <- assertIO(
+          importVk("bob_digest_fellowship", "digest_template", EMPTY_VK).run(
+            bobContext
+          ),
+          ExitCode.Success
+        )
+        _ <- IO(Files.delete(Paths.get(EMPTY_VK)))
+        BOB_DIGEST_ADDRESS <- walletController(BOB_WALLET)
+          .currentaddress("bob_digest_fellowship", "digest_template", None)
+        _ <- IO.println("Bob's digest address: " + BOB_DIGEST_ADDRESS)
+        _ <- IO.println("Moving funds (500 LVLs) from alice to bob digest")
+        _ <- assertIO(
+          createSimpleTransactionToAddress(
+            "self",
+            "default",
+            None,
+            None,
+            None,
+            None,
+            BOB_DIGEST_ADDRESS.get,
+            600,
+            BASE_FEE,
+            ALICE_SECOND_TX_RAW,
+            TokenType.lvl,
+            None,
+            None
+          ).run(aliceContext),
+          ExitCode.Success
+        )
+        _ <- assertIO(
+          proveSimpleTransaction(
+            ALICE_SECOND_TX_RAW,
+            ALICE_SECOND_TX_PROVED
+          ).run(aliceContext),
+          ExitCode.Success
+        )
+        _ <- assertIO(
+          broadcastSimpleTx(ALICE_SECOND_TX_PROVED),
+          ExitCode.Success
+        )
+        _ <- IO.println(
+          "Check digest account from bob's wallet, lvl tokens"
+        )
+        res <- IO.asyncForIO.timeout(
+          (for {
+            _ <- IO.println("Querying bob's digest")
+            queryRes <- queryAccount("bob_digest_fellowship", "digest_template").run(bobContext)
+            _ <- IO.sleep(5.seconds)
+          } yield queryRes)
+            .iterateUntil(_ == ExitCode.Success),
+          60.seconds
+        )
+      } yield res,
+      ExitCode.Success
+    )
+  }
+  test("Move funds from digest locked account to bob's normal account") {
+    import scala.concurrent.duration._
+    assertIO(
+      for {
+        _ <- assertIO(
+          addSecret("topl-secret", "sha256").run(bobContext),
+          ExitCode.Success
+        )
+        _ <- assertIO(
+          createSimpleTransactionToCartesianIdx(
+            "bob_digest_fellowship",
+            "digest_template",
+            None,
+            None,
+            None,
+            None,
+            "self",
+            "default",
+            500,
+            BASE_FEE,
+            BOB_FIRST_TX_RAW,
+            TokenType.lvl,
+            None,
+            None
+          ).run(bobContext),
+          ExitCode.Success
+        )
+        _ <- assertIO(
+          proveSimpleTransaction(
+            BOB_FIRST_TX_RAW,
+            BOB_FIRST_TX_PROVED
+          ).run(bobContext),
+          ExitCode.Success
+        )
+        _ <- assertIO(
+          broadcastSimpleTx(BOB_FIRST_TX_PROVED),
+          ExitCode.Success
+        )
+        _ <- IO.println(
+          "Check digest account from bob's wallet, lvl tokens"
+        )
+        res <- IO.asyncForIO.timeout(
+          (for {
+            _ <- IO.println("Querying bob's address")
+            queryRes <- queryAccount("self", "default").run(bobContext)
+            _ <- IO.sleep(5.seconds)
+          } yield queryRes)
+            .iterateUntil(_ == ExitCode.Success),
+          60.seconds
+        )
+      } yield res,
+      ExitCode.Success
+    )
+  }
+
+}

--- a/cli/src/it/scala/co/topl/brambl/cli/DigestTransactionTest.scala
+++ b/cli/src/it/scala/co/topl/brambl/cli/DigestTransactionTest.scala
@@ -94,7 +94,7 @@ class DigestTransactionTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          60.seconds
+          120.seconds
         )
       } yield res,
       ExitCode.Success
@@ -148,7 +148,7 @@ class DigestTransactionTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          60.seconds
+          120.seconds
         )
       } yield res,
       ExitCode.Success

--- a/cli/src/it/scala/co/topl/brambl/cli/DigestTransactionTest.scala
+++ b/cli/src/it/scala/co/topl/brambl/cli/DigestTransactionTest.scala
@@ -38,7 +38,7 @@ class DigestTransactionTest
         _ <- assertIO(
           addTemplateToWallet(
             "digest_template",
-            "threshold(1, sign(0) and sha256(b39f7e1305cd9107ed9af824fcb0729ce9888bbb7f219cc0b6731332105675dc))"
+            "threshold(1, sign(0) and sha256(ee15b31e49931db6551ed8a82f1422ce5a5a8debabe8e81a724c88f79996d0df))"
           ).run(bobContext),
           ExitCode.Success
         )

--- a/cli/src/it/scala/co/topl/brambl/cli/GeneralTransferTests.scala
+++ b/cli/src/it/scala/co/topl/brambl/cli/GeneralTransferTests.scala
@@ -87,7 +87,7 @@ class GeneralTransferTests
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          60.seconds
+          120.seconds
         )
       } yield res,
       ExitCode.Success
@@ -149,7 +149,7 @@ class GeneralTransferTests
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          60.seconds
+          120.seconds
         )
       } yield res,
       ExitCode.Success
@@ -212,7 +212,7 @@ class GeneralTransferTests
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          60.seconds
+          120.seconds
         )
       } yield res,
       ExitCode.Success

--- a/cli/src/it/scala/co/topl/brambl/cli/GeneralTransferTests.scala
+++ b/cli/src/it/scala/co/topl/brambl/cli/GeneralTransferTests.scala
@@ -87,7 +87,7 @@ class GeneralTransferTests
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          120.seconds
+          240.seconds
         )
       } yield res,
       ExitCode.Success
@@ -149,7 +149,7 @@ class GeneralTransferTests
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          120.seconds
+          240.seconds
         )
       } yield res,
       ExitCode.Success
@@ -212,7 +212,7 @@ class GeneralTransferTests
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          120.seconds
+          240.seconds
         )
       } yield res,
       ExitCode.Success

--- a/cli/src/it/scala/co/topl/brambl/cli/MintingFunctions.scala
+++ b/cli/src/it/scala/co/topl/brambl/cli/MintingFunctions.scala
@@ -70,7 +70,7 @@ trait MintingFunctions extends PolicyTemplates {
         _ <- IO.sleep(5.seconds)
       } yield queryRes)
         .iterateUntil(_ == ExitCode.Success),
-      120.seconds
+      240.seconds
     )
   } yield res
 
@@ -131,7 +131,7 @@ trait MintingFunctions extends PolicyTemplates {
         _ <- IO.sleep(5.seconds)
       } yield queryRes)
         .iterateUntil(_ == ExitCode.Success),
-      120.seconds
+      240.seconds
     )
   } yield res
 
@@ -201,7 +201,7 @@ trait MintingFunctions extends PolicyTemplates {
         _ <- IO.sleep(5.seconds)
       } yield queryRes)
         .iterateUntil(_ == ExitCode.Success),
-      120.seconds
+      240.seconds
     )
   } yield res
 

--- a/cli/src/it/scala/co/topl/brambl/cli/MintingFunctions.scala
+++ b/cli/src/it/scala/co/topl/brambl/cli/MintingFunctions.scala
@@ -70,7 +70,7 @@ trait MintingFunctions extends PolicyTemplates {
         _ <- IO.sleep(5.seconds)
       } yield queryRes)
         .iterateUntil(_ == ExitCode.Success),
-      60.seconds
+      120.seconds
     )
   } yield res
 
@@ -131,7 +131,7 @@ trait MintingFunctions extends PolicyTemplates {
         _ <- IO.sleep(5.seconds)
       } yield queryRes)
         .iterateUntil(_ == ExitCode.Success),
-      60.seconds
+      120.seconds
     )
   } yield res
 
@@ -201,7 +201,7 @@ trait MintingFunctions extends PolicyTemplates {
         _ <- IO.sleep(5.seconds)
       } yield queryRes)
         .iterateUntil(_ == ExitCode.Success),
-      60.seconds
+      120.seconds
     )
   } yield res
 

--- a/cli/src/it/scala/co/topl/brambl/cli/WalletDigestPropositionTest.scala
+++ b/cli/src/it/scala/co/topl/brambl/cli/WalletDigestPropositionTest.scala
@@ -80,7 +80,7 @@ class WalletDigestPropositionTest
       )
       _ <- assertIO(
         getPreimage(
-          "0a0f4e1461688b3dbf01cad2882e5779998efcf7ee3800c80e964fd0424d7e0c",
+          "ee15b31e49931db6551ed8a82f1422ce5a5a8debabe8e81a724c88f79996d0df",
           "sha256"
         ).run(walletContext),
         ExitCode.Success
@@ -89,7 +89,7 @@ class WalletDigestPropositionTest
         walletController(WALLET)
           .getPreimage(
             Sha256,
-            "0a0f4e1461688b3dbf01cad2882e5779998efcf7ee3800c80e964fd0424d7e0c"
+            "ee15b31e49931db6551ed8a82f1422ce5a5a8debabe8e81a724c88f79996d0df"
           )
           .map(_.toOption),
         Some("Preimage: topl-secret")
@@ -109,7 +109,7 @@ class WalletDigestPropositionTest
       )
       _ <- assertIO(
         getPreimage(
-          "a28f43e7ba06f79b31b189cfee16e160fba1c0ea8f2c4cc8ca38fa567fbca2e3",
+          "0a0f4e1461688b3dbf01cad2882e5779998efcf7ee3800c80e964fd0424d7e0c",
           "blake2b"
         ).run(walletContext),
         ExitCode.Success
@@ -118,7 +118,7 @@ class WalletDigestPropositionTest
         walletController(WALLET)
           .getPreimage(
             Blake2b,
-            "a28f43e7ba06f79b31b189cfee16e160fba1c0ea8f2c4cc8ca38fa567fbca2e3"
+            "0a0f4e1461688b3dbf01cad2882e5779998efcf7ee3800c80e964fd0424d7e0c"
           )
           .map(_.toOption),
         Some("Preimage: topl-secret")

--- a/cli/src/it/scala/co/topl/brambl/cli/WalletDigestPropositionTest.scala
+++ b/cli/src/it/scala/co/topl/brambl/cli/WalletDigestPropositionTest.scala
@@ -67,4 +67,62 @@ class WalletDigestPropositionTest
         )
       } yield ()
   }
+
+  tmpDirectory.test("Initialize wallet and add secret (sh256)") { _ =>
+    for {
+      _ <- createWallet().run(walletContext)
+      _ <- assertIO(
+        addSecret(
+          "topl-secret",
+          "sha256"
+        ).run(walletContext),
+        ExitCode.Success
+      )
+      _ <- assertIO(
+        getPreimage(
+          "b39f7e1305cd9107ed9af824fcb0729ce9888bbb7f219cc0b6731332105675dc",
+          "sha256"
+        ).run(walletContext),
+        ExitCode.Success
+      )
+      _ <- assertIO(
+        walletController(WALLET)
+          .getPreimage(
+            Sha256,
+            "b39f7e1305cd9107ed9af824fcb0729ce9888bbb7f219cc0b6731332105675dc"
+          )
+          .map(_.toOption),
+        Some("Preimage: topl-secret")
+      )
+    } yield ()
+  }
+
+  tmpDirectory.test("Initialize wallet and add secret (blake2b)") { _ =>
+    for {
+      _ <- createWallet().run(walletContext)
+      _ <- assertIO(
+        addSecret(
+          "topl-secret",
+          "blake2b"
+        ).run(walletContext),
+        ExitCode.Success
+      )
+      _ <- assertIO(
+        getPreimage(
+          "a28f43e7ba06f79b31b189cfee16e160fba1c0ea8f2c4cc8ca38fa567fbca2e3",
+          "blake2b"
+        ).run(walletContext),
+        ExitCode.Success
+      )
+      _ <- assertIO(
+        walletController(WALLET)
+          .getPreimage(
+            Blake2b,
+            "a28f43e7ba06f79b31b189cfee16e160fba1c0ea8f2c4cc8ca38fa567fbca2e3"
+          )
+          .map(_.toOption),
+        Some("Preimage: topl-secret")
+      )
+    } yield ()
+  }
 }

--- a/cli/src/it/scala/co/topl/brambl/cli/WalletDigestPropositionTest.scala
+++ b/cli/src/it/scala/co/topl/brambl/cli/WalletDigestPropositionTest.scala
@@ -80,7 +80,7 @@ class WalletDigestPropositionTest
       )
       _ <- assertIO(
         getPreimage(
-          "b39f7e1305cd9107ed9af824fcb0729ce9888bbb7f219cc0b6731332105675dc",
+          "0a0f4e1461688b3dbf01cad2882e5779998efcf7ee3800c80e964fd0424d7e0c",
           "sha256"
         ).run(walletContext),
         ExitCode.Success
@@ -89,7 +89,7 @@ class WalletDigestPropositionTest
         walletController(WALLET)
           .getPreimage(
             Sha256,
-            "b39f7e1305cd9107ed9af824fcb0729ce9888bbb7f219cc0b6731332105675dc"
+            "0a0f4e1461688b3dbf01cad2882e5779998efcf7ee3800c80e964fd0424d7e0c"
           )
           .map(_.toOption),
         Some("Preimage: topl-secret")

--- a/cli/src/it/scala/co/topl/brambl/cli/WalletDigestPropositionTest.scala
+++ b/cli/src/it/scala/co/topl/brambl/cli/WalletDigestPropositionTest.scala
@@ -68,7 +68,7 @@ class WalletDigestPropositionTest
       } yield ()
   }
 
-  tmpDirectory.test("Initialize wallet and add secret (sh256)") { _ =>
+  tmpDirectory.test("Initialize wallet and add secret (sha256)") { _ =>
     for {
       _ <- createWallet().run(walletContext)
       _ <- assertIO(

--- a/cli/src/it/scala/co/topl/brambl/cli/WalletRecoveryTest.scala
+++ b/cli/src/it/scala/co/topl/brambl/cli/WalletRecoveryTest.scala
@@ -42,7 +42,7 @@ class WalletRecoveryTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          120.seconds
+          240.seconds
         )
         next_address <- walletController(WALLET).currentaddress("self", "default", None)
         _ <- IO.println(s"Next address is $next_address")
@@ -83,7 +83,7 @@ class WalletRecoveryTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          120.seconds
+          240.seconds
         )
       } yield res,
       ExitCode.Success
@@ -155,7 +155,7 @@ class WalletRecoveryTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          120.seconds
+          240.seconds
         )
       } yield res,
       ExitCode.Success

--- a/cli/src/it/scala/co/topl/brambl/cli/WalletRecoveryTest.scala
+++ b/cli/src/it/scala/co/topl/brambl/cli/WalletRecoveryTest.scala
@@ -42,7 +42,7 @@ class WalletRecoveryTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          60.seconds
+          120.seconds
         )
         next_address <- walletController(WALLET).currentaddress("self", "default", None)
         _ <- IO.println(s"Next address is $next_address")
@@ -83,7 +83,7 @@ class WalletRecoveryTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          60.seconds
+          120.seconds
         )
       } yield res,
       ExitCode.Success
@@ -155,7 +155,7 @@ class WalletRecoveryTest
             _ <- IO.sleep(5.seconds)
           } yield queryRes)
             .iterateUntil(_ == ExitCode.Success),
-          60.seconds
+          120.seconds
         )
       } yield res,
       ExitCode.Success

--- a/cli/src/main/scala/co/topl/brambl/cli/BramblCliParams.scala
+++ b/cli/src/main/scala/co/topl/brambl/cli/BramblCliParams.scala
@@ -21,7 +21,8 @@ object BramblCliSubCmd extends Enumeration {
 
   val invalid, init, recoverkeys, utxobyaddress, blockbyheight, blockbyid,
       transactionbyid, create, prove, broadcast, currentaddress, list, add,
-      inspect, exportvk, importvks, sync, setinteraction, listinteraction, balance = Value
+      inspect, exportvk, addsecret, getpreimage, importvks, sync, setinteraction,
+      listinteraction, balance = Value
 }
 
 sealed abstract class NetworkIdentifiers(
@@ -69,11 +70,37 @@ object TokenType extends Enumeration {
   val all, lvl, topl, asset, group, series = Value
 }
 
+object DigestType {
+
+  def withName(name: String): DigestType = {
+    name match {
+      case "sha256"  => Sha256
+      case "blake2b" => Blake2b
+      case _         => InvalidDigest
+    }
+  }
+}
+
+sealed abstract class DigestType(
+    val shortName: String,
+    val digestIdentifier: String
+) {
+
+
+}
+
+case object Sha256 extends DigestType("sha256", "Sha256")
+case object Blake2b extends DigestType("blake2b", "Blake2b256")
+case object InvalidDigest extends DigestType("invalid", "Invalid")
+
 final case class BramblCliParams(
     mode: BramblCliMode.Value = BramblCliMode.invalid,
     subcmd: BramblCliSubCmd.Value = BramblCliSubCmd.invalid,
     tokenType: TokenType.Value = TokenType.all,
     network: NetworkIdentifiers = InvalidNet,
+    secret: String = "",
+    digestText: String = "",
+    digest: DigestType = InvalidDigest,
     fellowshipName: String = "self",
     templateName: String = "default",
     lockTemplate: String = "",

--- a/cli/src/main/scala/co/topl/brambl/cli/BramblCliParamsParserModule.scala
+++ b/cli/src/main/scala/co/topl/brambl/cli/BramblCliParamsParserModule.scala
@@ -167,6 +167,8 @@ object BramblCliParamsParserModule {
   val secretArg = opt[String]("secret")
     .validate(x =>
       if (x.trim().isEmpty) failure("Secret may not be empty")
+      else if (x.trim().getBytes().length > 32)
+        failure("Secret (in bytes) may not be longer than 32 bytes")
       else success
     )
     .action((x, c) => c.copy(secret = x))

--- a/cli/src/main/scala/co/topl/brambl/cli/BramblCliParamsParserModule.scala
+++ b/cli/src/main/scala/co/topl/brambl/cli/BramblCliParamsParserModule.scala
@@ -1,17 +1,17 @@
 package co.topl.brambl.cli
 
 import co.topl.brambl.codecs.AddressCodecs
+import co.topl.brambl.constants.NetworkConstants
+import co.topl.brambl.models.GroupId
 import co.topl.brambl.models.LockAddress
+import co.topl.brambl.models.SeriesId
 import co.topl.brambl.utils.Encoding
+import com.google.protobuf.ByteString
 import scopt.OParser
 
 import java.io.File
 import java.nio.file.Paths
-import co.topl.brambl.models.GroupId
-import com.google.protobuf.ByteString
-import co.topl.brambl.models.SeriesId
 import scala.util.Try
-import co.topl.brambl.constants.NetworkConstants
 
 object BramblCliParamsParserModule {
 
@@ -38,6 +38,10 @@ object BramblCliParamsParserModule {
             "Invalid network. Possible values: mainnet, testnet, private"
           )
       })
+
+  implicit val digestRead: scopt.Read[DigestType] =
+    scopt.Read
+      .reads(DigestType.withName(_))
 
   implicit val groupIdRead: scopt.Read[GroupId] =
     scopt.Read.reads { x =>
@@ -159,6 +163,31 @@ object BramblCliParamsParserModule {
     )
     .action((x, c) => c.copy(fellowshipName = x))
     .text("Name of the fellowship. (mandatory)")
+
+  val secretArg = opt[String]("secret")
+    .validate(x =>
+      if (x.trim().isEmpty) failure("Secret may not be empty")
+      else success
+    )
+    .action((x, c) => c.copy(secret = x))
+    .text("Secret to be encoded. (mandatory)")
+    .required()
+
+  val digestArg = opt[DigestType]("digest")
+    .action((x, c) => c.copy(digest = x))
+    .text("Digest algorithm used to encode the secret. (mandatory)")
+    .required()
+
+  val digestTextArg = opt[String]("digest-text")
+    .action((x, c) => c.copy(digestText = x))
+    .validate { x =>
+      if (x.trim().isEmpty) failure("Digest text may not be empty")
+      else if (Encoding.decodeFromHex(x).isRight)
+        success
+      else failure("Invalid digest text")
+    }
+    .text("Digest text to query for preimage. (mandatory)")
+    .required()
 
   def validateWalletDbFile(walletDbFile: String): Either[String, Unit] =
     if (walletDbFile.trim().isEmpty) failure("Wallet file may not be empty")
@@ -375,7 +404,7 @@ object BramblCliParamsParserModule {
         .action((_, c) => c.copy(subcmd = BramblCliSubCmd.init))
         .text("Run the server")
         .children(
-          (Seq(walletDbArg.required()) ++ Seq(secureArg) ++ 
+          (Seq(walletDbArg.required()) ++ Seq(secureArg) ++
             keyfileAndPassword.map(_.required()) ++ hostPortNetwork.reverse.tail
               .map(_.required())): _*
         )
@@ -616,6 +645,22 @@ object BramblCliParamsParserModule {
               .action((x, c) => c.copy(someFromInteraction = x))
               .text("Interaction from where we are sending the funds from")
           )): _*
+        ),
+      cmd("add-secret")
+        .action((_, c) => c.copy(subcmd = BramblCliSubCmd.addsecret))
+        .text("Add a secret to the wallet")
+        .children(
+          walletDbArg,
+          secretArg,
+          digestArg
+        ),
+      cmd("get-preimage")
+        .action((_, c) => c.copy(subcmd = BramblCliSubCmd.getpreimage))
+        .text("Get a preimage from the wallet")
+        .children(
+          walletDbArg,
+          digestTextArg,
+          digestArg
         ),
       cmd("import-vks")
         .action((_, c) => c.copy(subcmd = BramblCliSubCmd.importvks))

--- a/cli/src/main/scala/co/topl/brambl/cli/controllers/TxController.scala
+++ b/cli/src/main/scala/co/topl/brambl/cli/controllers/TxController.scala
@@ -1,11 +1,15 @@
 package co.topl.brambl.cli.controllers
 
-import cats.effect.kernel.{Resource, Sync}
-import co.topl.brambl.cli.impl.{CommonParserError, TransactionAlgebra, TxParserAlgebra}
+import cats.effect.kernel.Resource
+import cats.effect.kernel.Sync
+import co.topl.brambl.cli.impl.CommonParserError
+import co.topl.brambl.cli.impl.TransactionAlgebra
+import co.topl.brambl.cli.impl.TxParserAlgebra
 import co.topl.brambl.display.DisplayOps.DisplayTOps
 import co.topl.brambl.models.transaction.IoTransaction
 
-import java.io.{FileInputStream, FileOutputStream}
+import java.io.FileInputStream
+import java.io.FileOutputStream
 
 class TxController[F[_]: Sync](
     txParserAlgebra: TxParserAlgebra[F],
@@ -16,7 +20,6 @@ class TxController[F[_]: Sync](
       inputFile: String
   ) = {
     import cats.implicits._
-    import co.topl.brambl.cli.views.BlockDisplayOps._
     val inputRes = Resource
       .make(
         Sync[F]

--- a/cli/src/main/scala/co/topl/brambl/cli/controllers/WalletController.scala
+++ b/cli/src/main/scala/co/topl/brambl/cli/controllers/WalletController.scala
@@ -26,6 +26,13 @@ import quivr.models.VerificationKey
 
 import java.io.File
 import java.io.PrintWriter
+import quivr.models.Preimage
+import com.google.protobuf.ByteString
+import quivr.models.Proposition
+import co.topl.brambl.cli.DigestType
+import quivr.models.Digest
+import co.topl.brambl.cli.Sha256
+import co.topl.crypto.hash.Blake2b256
 
 class WalletController[F[_]: Sync](
     walletStateAlgebra: dataApi.WalletStateAlgebra[F],
@@ -34,6 +41,85 @@ class WalletController[F[_]: Sync](
     walletAlgebra: WalletAlgebra[F],
     genusQueryAlgebra: dataApi.GenusQueryAlgebra[F]
 ) {
+
+  def addSecret(
+      secretTxt: String,
+      digest: DigestType
+  ): F[Either[String, String]] = {
+    import cats.implicits._
+    val paddedSecret = secretTxt.getBytes() ++ Array
+      .fill(secretTxt.getBytes().length - 32)(0.toByte)
+    val hashedSecret =
+      if (digest == Sha256)
+        java.security.MessageDigest
+          .getInstance("SHA-256")
+          .digest(
+            paddedSecret
+          )
+      else
+        (new Blake2b256).hash(
+          paddedSecret
+        )
+    val propDigest = Proposition.Digest(
+      digest.digestIdentifier,
+      Digest(
+        ByteString.copyFrom(
+          hashedSecret
+        )
+      )
+    )
+    for {
+      somePreimage <- walletStateAlgebra.getPreimage(
+        propDigest
+      )
+      res <-
+        if (somePreimage.isEmpty)
+          walletStateAlgebra
+            .addPreimage(
+              Preimage(
+                ByteString.copyFrom(secretTxt.getBytes()),
+                ByteString.copyFrom(
+                  Array.fill(secretTxt.getBytes().length - 32)(0.toByte)
+                )
+              ),
+              propDigest
+            )
+            .map { _ =>
+              Right(
+                "Secret added. Hash: " + Encoding.encodeToHex(hashedSecret)
+              )
+            }
+        else
+          Sync[F].pure(Left("Secret already exists"))
+    } yield res
+  }
+
+  def getPreimage(
+      digest: DigestType,
+      digestTxt: String
+  ): F[Either[String, String]] = {
+    import cats.implicits._
+    for {
+      decodedDigest <- Sync[F].fromEither(Encoding.decodeFromHex(digestTxt))
+      propDigest = Proposition.Digest(
+        digest.digestIdentifier,
+        Digest(
+          ByteString.copyFrom(
+            decodedDigest
+          )
+        )
+      )
+      somePreimage <- walletStateAlgebra.getPreimage(
+        propDigest
+      )
+    } yield somePreimage match {
+      case Some(preimage) =>
+        Right(
+          "Preimage: " + new String(preimage.input.toByteArray)
+        )
+      case None => Left("Preimage not found.")
+    }
+  }
 
   def importVk(
       networkId: Int,
@@ -60,19 +146,22 @@ class WalletController[F[_]: Sync](
         })
         .sequence
         .flatMap(
-          _.map(_.trim()).filterNot(_.isEmpty()).map(
-            // TODO: replace with proper serialization in TSDK-476
-            vk =>
-              // we derive the key once
-              walletApi
-                .deriveChildVerificationKey(
-                  VerificationKey.parseFrom(
-                    Encoding.decodeFromBase58(vk).toOption.get
-                  ),
-                  1
-                )
-                .map(x => (x, vk))
-          ).sequence
+          _.map(_.trim())
+            .filterNot(_.isEmpty())
+            .map(
+              // TODO: replace with proper serialization in TSDK-476
+              vk =>
+                // we derive the key once
+                walletApi
+                  .deriveChildVerificationKey(
+                    VerificationKey.parseFrom(
+                      Encoding.decodeFromBase58(vk).toOption.get
+                    ),
+                    1
+                  )
+                  .map(x => (x, vk))
+            )
+            .sequence
         )
       lockTempl <- walletStateAlgebra
         .getLockTemplate(templateName)

--- a/cli/src/main/scala/co/topl/brambl/cli/controllers/WalletController.scala
+++ b/cli/src/main/scala/co/topl/brambl/cli/controllers/WalletController.scala
@@ -46,16 +46,15 @@ class WalletController[F[_]: Sync](
       secretTxt: String,
       digest: DigestType
   ): F[Either[String, String]] = {
+    import co.topl.crypto.hash.implicits.sha256Hash
     import cats.implicits._
     val paddedSecret = secretTxt.getBytes() ++ Array
       .fill(secretTxt.getBytes().length - 32)(0.toByte)
     val hashedSecret =
       if (digest == Sha256)
-        java.security.MessageDigest
-          .getInstance("SHA-256")
-          .digest(
+        sha256Hash.hash(
             paddedSecret
-          )
+          ).value
       else
         (new Blake2b256).hash(
           paddedSecret

--- a/cli/src/main/scala/co/topl/brambl/cli/controllers/WalletController.scala
+++ b/cli/src/main/scala/co/topl/brambl/cli/controllers/WalletController.scala
@@ -78,7 +78,7 @@ class WalletController[F[_]: Sync](
               Preimage(
                 ByteString.copyFrom(secretTxt.getBytes()),
                 ByteString.copyFrom(
-                  Array.fill(secretTxt.getBytes().length - 32)(0.toByte)
+                  Array.fill(32 - secretTxt.getBytes().length)(0.toByte)
                 )
               ),
               propDigest

--- a/cli/src/main/scala/co/topl/brambl/cli/controllers/WalletController.scala
+++ b/cli/src/main/scala/co/topl/brambl/cli/controllers/WalletController.scala
@@ -148,7 +148,7 @@ class WalletController[F[_]: Sync](
           _.map(_.trim())
             .filterNot(_.isEmpty())
             .map(
-              // TODO: replace with proper serialization in TSDK-476
+              // TODO: replace with proper serialization
               vk =>
                 // we derive the key once
                 walletApi

--- a/cli/src/main/scala/co/topl/brambl/cli/controllers/WalletController.scala
+++ b/cli/src/main/scala/co/topl/brambl/cli/controllers/WalletController.scala
@@ -49,7 +49,7 @@ class WalletController[F[_]: Sync](
     import co.topl.crypto.hash.implicits.sha256Hash
     import cats.implicits._
     val paddedSecret = secretTxt.getBytes() ++ Array
-      .fill(secretTxt.getBytes().length - 32)(0.toByte)
+      .fill(32 - secretTxt.getBytes().length)(0.toByte)
     val hashedSecret =
       if (digest == Sha256)
         sha256Hash.hash(

--- a/cli/src/main/scala/co/topl/brambl/cli/modules/WalletModeModule.scala
+++ b/cli/src/main/scala/co/topl/brambl/cli/modules/WalletModeModule.scala
@@ -49,6 +49,13 @@ trait WalletModeModule
           else None,
           validateParams.someFromInteraction
         )
+      case BramblCliSubCmd.addsecret =>
+        walletController.addSecret(validateParams.secret, validateParams.digest)
+      case BramblCliSubCmd.getpreimage =>
+        walletController.getPreimage(
+          validateParams.digest,
+          validateParams.digestText
+        )
       case BramblCliSubCmd.invalid =>
         IO.pure(
           Left(

--- a/cli/src/test/scala/co/topl/brambl/cli/ParamsWalletModuleTest.scala
+++ b/cli/src/test/scala/co/topl/brambl/cli/ParamsWalletModuleTest.scala
@@ -5,7 +5,6 @@ import scopt.OParser
 
 import java.nio.file.Files
 import java.nio.file.Paths
-import java.nio.file.Path
 
 class ParamsWalletModuleTest extends FunSuite {
 

--- a/cli/src/test/scala/co/topl/brambl/cli/controllers/WalletControllerSpecs.scala
+++ b/cli/src/test/scala/co/topl/brambl/cli/controllers/WalletControllerSpecs.scala
@@ -310,7 +310,7 @@ class WalletControllerSpecs extends CatsEffectSuite with WalletKeyApiModule {
           Sha256
         )
       } yield res,
-      Right("Secret added. Hash: b39f7e1305cd9107ed9af824fcb0729ce9888bbb7f219cc0b6731332105675dc")
+      Right("Secret added. Hash: ee15b31e49931db6551ed8a82f1422ce5a5a8debabe8e81a724c88f79996d0df")
     )
   }
 
@@ -380,7 +380,7 @@ class WalletControllerSpecs extends CatsEffectSuite with WalletKeyApiModule {
           Blake2b
         )
       } yield res,
-      Right("Secret added. Hash: a28f43e7ba06f79b31b189cfee16e160fba1c0ea8f2c4cc8ca38fa567fbca2e3")
+      Right("Secret added. Hash: 0a0f4e1461688b3dbf01cad2882e5779998efcf7ee3800c80e964fd0424d7e0c")
     )
   }
 }

--- a/microsite/docs/cli-reference/wallet-mode.md
+++ b/microsite/docs/cli-reference/wallet-mode.md
@@ -4,8 +4,8 @@ sidebar_position: 5
 
 # Wallet Mode
 
-```                           
-Command: wallet [balance|set-interaction|list-interactions|sync|init|recover-keys|current-address|export-vk|import-vks]
+```
+Command: wallet [balance|set-interaction|list-interactions|sync|init|recover-keys|current-address|export-vk|add-secret|get-preimage|import-vks]
 Wallet mode
 Command: wallet balance [options]
 Get balance of wallet
@@ -63,7 +63,7 @@ Recover Wallet Main Key
   -o, --output <value>     The output file. (mandatory)
   --newwalletdb <value>    Wallet DB file. (mandatory)
   -P, --passphrase <value>
-                           Passphrase for the encrypted key. (optional)
+                           Passphrase for the encrypted key. (optional))
 Command: wallet current-address [options]
 Obtain current address
   --walletdb <value>       Wallet DB file. (mandatory)
@@ -82,6 +82,16 @@ Export verification key
                            Name of the fellowship. (mandatory)
   --template-name <value>  Name of the template. (mandatory)
   --interaction <value>    Interaction from where we are sending the funds from
+Command: wallet add-secret [options]
+Add a secret to the wallet
+  --walletdb <value>       Wallet DB file. (mandatory)
+  --secret <value>         Secret to be encoded. (mandatory)
+  --digest <value>         Digest algorithm used to encode the secret. (mandatory)
+Command: wallet get-preimage [options]
+Get a preimage from the wallet
+  --walletdb <value>       Wallet DB file. (mandatory)
+  --digest-text <value>    Digest text to query for preimage. (mandatory)
+  --digest <value>         Digest algorithm used to encode the secret. (mandatory)
 Command: wallet import-vks [options]
 Import verification key
   -k, --keyfile <value>    The key file.

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object Dependencies {
 
   lazy val toplOrg = "co.topl"
 
-  lazy val bramblVersion = "2.0.0-beta2"
+  lazy val bramblVersion = "2.0.0-beta3"
   val bramblSdk = toplOrg %% "brambl-sdk" % bramblVersion 
   val circeVersion = "0.15.0-M1"
 


### PR DESCRIPTION
## Purpose

The goal of this task is to finish the implementation of the digest support.

## Approach

We added two new operations to the wallet: `add-secret` and `get-preimage`. These are used to both add a secret to the wallet (which will later be used to prove transactions using the hash) and get the secret for a given hash resepectively.

## Testing

We added unit tests and integration tests.

## Tickets

* TSDK-761